### PR TITLE
[New] Articles template and markdown scenarios

### DIFF
--- a/src/stylesheets/components/_article.scss
+++ b/src/stylesheets/components/_article.scss
@@ -1,0 +1,48 @@
+article {
+  margin-bottom: $base-spacing-unit-small;
+  li {
+    list-style: none;
+    &::before {
+      content: '';
+      display: inline-block;
+      position: relative;
+      color: $white;
+      font-weight: 500;
+      text-align: center;
+      background-color: $deep-purple;
+    }
+  }
+  ul {
+    > li {
+      margin: $base-spacing-unit-tiny 0;
+      &::before {
+        top: -2px;
+        left: -$base-spacing-unit-tiny;
+        width: 8px;
+        height: 8px;
+        border-radius: 4px;
+        margin-left: -8px;
+      }
+    }
+  }
+  ol {
+    margin-left: ($base-spacing-unit-extra-large + $base-spacing-unit-small);
+    > li {
+      counter-increment: item;
+      margin: $base-spacing-unit-medium 0;
+      &::before {
+        content: counter(item);
+        left:        -($base-spacing-unit-medium + 2);
+        width:        ($base-spacing-unit-large - 2);
+        height:       ($base-spacing-unit-large - 2);
+        line-height:  ($base-spacing-unit-large - 2);
+        margin-left: -($base-spacing-unit-large - 2);
+      }
+
+      > ul {
+        margin-top: $base-spacing-unit-medium;
+        margin-bottom: $base-spacing-unit-medium;
+      }
+    }
+  }
+}

--- a/src/stylesheets/components/_list-styles.scss
+++ b/src/stylesheets/components/_list-styles.scss
@@ -90,6 +90,7 @@ dl, dt, dd {
 }
 
 @mixin list--block {
+  width: 100%;
   @include list;
 
   > li {

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -29,6 +29,7 @@
 @import 'elements/typography';
 
 /*--- Import Components ---*/
+@import 'components/article';
 @import 'components/buttons';
 @import 'components/dropdown';
 @import 'components/footer';

--- a/src/stylesheets/objects/_content-layouts.scss
+++ b/src/stylesheets/objects/_content-layouts.scss
@@ -73,6 +73,18 @@ header .container {
   @include block;
 }
 
+.block--transparent {
+  background-color: transparent;
+  padding-right: $base-spacing-unit-medium;
+  margin-bottom: $base-spacing-unit-small;
+}
+
+.block--offset {
+  @include media($tablet) {
+    padding-right: ($base-spacing-unit-extra-large * 6);
+  }
+}
+
 @mixin block__deep {
   @include block;
   padding-top: $base-spacing-unit-extra-large;
@@ -112,6 +124,14 @@ header .container {
     @include media($desktop) {
       padding-bottom: ($base-spacing-unit-large - 1); // -1px to compensate for border height
     }
+  }
+}
+
+// Styles for flexbox grid
+
+.flex--2 {
+  @include media($tablet) {
+    @include flex(50%);
   }
 }
 

--- a/src/stylesheets/settings/_mixins.scss
+++ b/src/stylesheets/settings/_mixins.scss
@@ -197,3 +197,21 @@
     display: block;
   }
 }
+
+/*--- Flexbox grid ---*/
+
+@mixin flex($flex-basis:null, $gutter-width:null) {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+
+  > [class*='block'] {
+    @if $flex-basis {
+      flex-basis: if(
+        $gutter-width,
+        calc(#{$flex-basis} - (#{$gutter-width} / 2)),
+        $flex-basis
+      );
+    }
+  }
+}

--- a/src/templates/index.pug
+++ b/src/templates/index.pug
@@ -24,6 +24,7 @@ html(lang="en")
             li #[+link('/templates/prototypes/constituency.html', 'Constituency')]
             li #[+link('/templates/prototypes/_map.html', 'Constituency map')]
             li #[+link('/templates/prototypes/media-id.html', 'Media ID')]
+            li #[+link('/templates/prototypes/article.html', 'Article')]
 
       section
         .container
@@ -38,6 +39,7 @@ html(lang="en")
             li #[+link('/templates/prototypes/_tables.html', 'Tables')]
             li #[+link('/templates/prototypes/_tracks.html', 'Tracks')]
             li #[+link('/templates/prototypes/_toggles.html', 'Toggles')]
+            li #[+link('/templates/prototypes/_article.html', 'Article')]
 
 
       section

--- a/src/templates/prototypes/_article.pug
+++ b/src/templates/prototypes/_article.pug
@@ -1,0 +1,69 @@
+extends ../../layouts/layout.pug
+block content
+  -var thingPage = true
+
+  .section--primary(tabindex=0)#content
+    .container
+      .block--border__bottom.block--offset
+        h1 Article elements
+        p A demo of how html content will display in the article tag
+
+  section
+    article
+      .container--offset
+        h1 Heading 1
+        h2 Heading 2
+        h3 Heading 3
+
+        h2 Links
+        p #[+link('#', 'A link')]
+        p This is #[+link('#', 'another link')]
+
+        h2 Emphasis
+        p
+          strong This text is bold
+        p
+          em This text is italic
+        p
+          del This text has a strikethrough
+
+        h2 Blockquotes
+        blockquote
+          p Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+        h2 Lists
+
+        h3 Ordered
+        ol
+          li List item 1
+          li List item 2
+          li List item 3
+
+        h3 Unordered
+        ul
+          li List item
+          li List item
+          li List item
+
+        h3 Unordered in ordered
+        ol
+          li List item 1
+          li List item 2
+            ul
+              li List item
+              li List item
+              li List item
+          li List item 3
+
+        h3 Ordered in unordered
+        ul
+          li List item
+          li List item
+            ol
+              li List item 1
+              li List item 2
+              li List item 3
+          li List item
+
+        h2 Images
+        img(src="https://api-parliament-uk.azure-api.net/Staging/photo/0qLRSwb3.jpeg?width=732&quality=80" alt="Margot James")

--- a/src/templates/prototypes/article.pug
+++ b/src/templates/prototypes/article.pug
@@ -1,0 +1,26 @@
+extends ../../layouts/layout.pug
+block content
+  -var thingPage = true
+
+  .section--primary(tabindex=0)#content
+    .container
+      .block--border__bottom.block--offset
+        h1 How to submit an oral question on paper
+        p.lead MPs Guide to Procedure
+        p These steps are for submitting on oral question on paper.
+        p You can also submit an oral question online.
+        p You or your staff can complete these steps, but your handwritten signature is needed for step 3
+
+  section
+    article
+      .container--offset
+        h2 Steps
+        ol
+          li Use the Question Time rota (PDF, 45 KB) to find out which departments are due to answer questions. The deadline for tabling oral questions is 12.30pm three sitting days before the Question Time takes place (or five sitting days for Northern Ireland, Scotland and Wales questions). A sitting day is a day when the House is meeting.
+          li Fill in a question form (download a question form (Word doc, 39 KB) from the intranet or get one from the Table Office or Procedural Hub).
+            ul
+              li Tick the box to specify that it is an oral question. Fill in your name, constituency and the relevant department.
+              li Write the text of your question in the blank space on the form. Check it conforms to the rules for questions. To submit a topical question, write 'T' in the blank space. You can table one substantive and one topical question (check the rota to see whether there are topical questions for that department) for each departmental Question Time. A substantive question means you submit the text of the question in advance. A topical question means there is no need to submit the text in advance.
+              li If you are asking a substantive question and have an interest to declare, tick the box and email tableoffice@parliament.uk to say what the interest is.
+          li Take your question form to the Table Office or Procedural Hub in person, or ask another MP to take it for you. Or sign the question form and post it or ask your staff to take it to the Table Office or Procedural Hub (faxed, stamped or photocopied signatures cannot be accepted).
+          li The Table Office will check your question and contact you if they have a problem. Once the Table Office has approved your question, it has been tabled.


### PR DESCRIPTION
1. Template for how an article should look
  - Article tag's ol and ul tags have a new style treatment

2. Template for what elements will render from markdown

3. New class `.block--offset` to add padding-right of 216px for `.block--border__bottom`

> Note: If we're going to use `.container--offset` for all articles, which displays rendered markdown, you will notice that images, tables and blockquotes will not take the full width of the container.