### PR TITLE
[WEBDEV-503] Fix missing list-style for number, roman and alpha

### DIFF
--- a/src/stylesheets/components/_list-styles.scss
+++ b/src/stylesheets/components/_list-styles.scss
@@ -234,6 +234,13 @@ aside .list--pipe li:last-child {
   }
 }
 
+.list--number, .list--roman, .list--alpha {
+  @include list;
+  li {
+    margin-left: $base-spacing-unit-large;
+  }
+}
+
 .list--number {
   list-style-type: decimal;
 }
@@ -244,13 +251,6 @@ aside .list--pipe li:last-child {
 
 .list--alpha {
   list-style-type: lower-alpha;
-}
-
-.list--number, .list--roman, .list--alpha {
-  @include list;
-  li {
-    margin-left: $base-spacing-unit-large;
-  }
 }
 
 /*--- Default Nested Lists [ul/ol] ---*/


### PR DESCRIPTION
List styles for `.list--[number, roman, alpha]` was being overridden with "list-style: none" in the list mixin. This has been amended by moving the code on lines 247-254 higher up in the page in the _list-styles.scss, which is now on lines 237-242.