### PR TITLE
[GTP-209] Make amends to print styles

### DIFF
--- a/src/stylesheets/components/_aside.scss
+++ b/src/stylesheets/components/_aside.scss
@@ -9,4 +9,10 @@ aside {
   .block {
     @extend .theme--grey-4;
   }
+
+  /*--- Print styles ---*/
+
+  @media print {
+    display: none;
+  }
 }

--- a/src/stylesheets/components/_footer.scss
+++ b/src/stylesheets/components/_footer.scss
@@ -20,4 +20,10 @@ body > {
 
 article footer {
   margin-top: round($base-spacing-unit * 9);
+
+  /*--- Print Styles ---*/
+
+  @media print {
+    display: none;
+  }
 }

--- a/src/stylesheets/components/_highlight.scss
+++ b/src/stylesheets/components/_highlight.scss
@@ -39,12 +39,26 @@
 .status--banner,
 .status--banner__beta {
   @include status--banner;
+
+  /*--- Print styles ---*/
+
+  @media print {
+    display: none;
+  }
 }
 
 .status--banner.cookie {
   display: none;
   &.show {
     display: block;
+  }
+
+  /*--- Print styles ---*/
+
+  @media print {
+    &.show {
+      display: none;
+    }
   }
 }
 

--- a/src/stylesheets/components/_list-styles.scss
+++ b/src/stylesheets/components/_list-styles.scss
@@ -295,7 +295,7 @@ footer .list {
 article [role='main'] {
   li {
     list-style: none;
-    &::before {
+    &:before {
       content: '';
       display: inline-block;
       position: relative;
@@ -308,7 +308,7 @@ article [role='main'] {
   ul {
     > li {
       margin: $base-spacing-unit-tiny 0;
-      &::before {
+      &:before {
         top: -2px;
         left: -$base-spacing-unit-tiny;
         width: 8px;
@@ -323,7 +323,7 @@ article [role='main'] {
     > li {
       counter-increment: item;
       margin: $base-spacing-unit-medium 0;
-      &::before {
+      &:before {
         content: counter(item);
         left:        -($base-spacing-unit-medium + 2);
         width:        ($base-spacing-unit-large - 2);
@@ -336,6 +336,22 @@ article [role='main'] {
         margin-top: $base-spacing-unit-medium;
         margin-bottom: $base-spacing-unit-medium;
       }
+    }
+  }
+
+  /*--- Print styles ---*/
+
+  @media print {
+    ul > li, ol > li {
+      &:before {
+        content: none;
+      }
+    }
+    ul > li {
+      list-style-type: disc;
+    }
+    ol > li {
+      list-style-type: decimal;
     }
   }
 }


### PR DESCRIPTION
* Looks good on Chrome, Safari, Firefox, Edge, IE11
* Hidden the status banners, sidebar, article footer
* Added default list-style-type in articles and removed the styled `::before` pseudo-classes, because the way the lists render for print varies between browsers.

  * In IE pseudo classes aren't visible
  * In Chrome background colours aren't present unless a user manually sets an option to show it.