### PR TITLE
[GTP-254] Implement icons and buttons for print, download, share

### DIFF
--- a/src/elements/_utilities.pug
+++ b/src/elements/_utilities.pug
@@ -1,0 +1,13 @@
+ul.list--inline
+  li.visually-hidden(aria-hidden='true')
+    .list--details
+      include ../icons/print.svg
+      +link('#', 'Print page').btn--print
+  li
+    .list--details
+      include ../icons/download.svg
+      +link('#', 'Download as PDF')
+  li
+    .list--details
+      include ../icons/share.svg
+      +link('#', 'Share')

--- a/src/icons/download.svg
+++ b/src/icons/download.svg
@@ -1,5 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 38 50" aria-hidden="true">
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true">
   <title>Download icon</title>
-  <polygon points="37 44 1 44 1 50 37 50"></polygon>
-  <path d="M16,0 L16,29.7 L4.4,18.8 L0.3,23.2 L17,38.8 C17.6,39.3 18.3,39.6 19,39.6 C19.7,39.6 20.5,39.3 21,38.8 L37.6,23.3 L33.5,18.9 L22,29.7 L22,0 L16,0 Z"></path>
+  <g fill="#373150">
+    <path d="M1,18L19,18L19,20L1,20Z"/>
+    <path d="M8.973,0V12.743L5.349,9,4,10.448l5.3,5.289A1.045,1.045,0,0,0,9.96,16a0.978,0.978,0,0,0,.658-0.263L16,10.448,14.651,9l-3.7,3.743V0H8.973Z"/>
+  </g>
 </svg>

--- a/src/icons/print.svg
+++ b/src/icons/print.svg
@@ -1,9 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true">
-    <title>Print icon</title>
-    <g stroke="#717171" fill="#EBE9E8" shape-rendering="crispEdges">
-      <rect width="10" height="5" x="5" y="1"></rect>
-      <rect width="18" height="11" x="1" y="5"></rect>
-      <rect width="10" height="9" x="5" y="10"></rect>
-      <line x1="17" y1="6" x2="17" y2="7" />
-    </g>
+  <title>Print icon</title>
+  <g fill="#373150">
+    <path d="M15,1H5A2.006,2.006,0,0,0,3,3V5H17V3A2.006,2.006,0,0,0,15,1Z"/>
+    <polygon points="0 6 0 17 2.58 17 3.02 14.804 3.18 14 4 14 16 14 16.82 14 16.98 14.804 17.42 17 20 17 20 6 0 6"/>
+    <polyline points="16 15 17 20 3 20 4 15 16 15"/>
+  </g>
 </svg>

--- a/src/icons/share.svg
+++ b/src/icons/share.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true">
+  <title>Share icon</title>
+  <g fill="#373150">
+    <circle cx="3.5" cy="10" r="3.5"/>
+    <circle cx="16.5" cy="3.5" r="3.5"/>
+    <circle cx="16.5" cy="16.5" r="3.5"/>
+    <rect x="4.432" y="5.453" width="12" height="2" transform="translate(-1.753 5.039) rotate(-25.122)"/>
+    <rect x="9.398" y="7.62" width="2" height="12" transform="translate(-6.395 17.027) rotate(-64.11)"/>
+  </g>
+</svg>

--- a/src/javascripts/_helpers.js
+++ b/src/javascripts/_helpers.js
@@ -54,11 +54,49 @@ var UK_Parliament = (function () {
         }
       };
       request.send();
+    },
+
+    /**
+     * Get ancestor of an element based on matching attributes by traversing up the DOM
+     * @param {object} element The element to traverse from
+     * @param {object} attributes HTML attributes with values to check against
+     * @param {function} callback Allows user to modify the matching parent element
+     *
+     * @return Returns parent element that contains all specified `attributes`
+     */
+    traverseUp = function (element, attributes, callback) {
+
+      var
+        parent = element.parentElement,
+        attrs = Object.keys(attributes);
+
+      if (parent) {
+
+        for (var i = 0; i < attrs.length; i++) {
+          if (
+            parent.hasAttribute(attrs[i]) &&
+            parent.getAttribute(attrs[i]) === attributes[attrs[i]]
+          ) {
+            if ((i + 1) === attrs.length) {
+              return callback ? callback(parent) : parent;
+            } else {
+              continue;
+            }
+          } else {
+            return this.traverseUp(parent, attributes, callback);
+          }
+        }
+
+      }
+
+      throw 'Sorry, there is no such ancestor with the identifiers you referenced: ' + JSON.stringify(attributes);
+
     };
 
   return {
     setCookie: setCookie,
     getCookie: getCookie,
-    httpRequest: httpRequest
+    httpRequest: httpRequest,
+    traverseUp: traverseUp
   };
 })();

--- a/src/javascripts/print_button.js
+++ b/src/javascripts/print_button.js
@@ -1,0 +1,35 @@
+// Open the print dialog when clicking the print button
+
+UK_Parliament.printButton = function () {
+
+  var
+    printButtons = document.querySelectorAll('.btn--print');
+
+  if (printButtons) {
+    for (var i = 0; i < printButtons.length; i++) {
+
+      // Add click event to print buttons
+      printButtons[i].onclick = function(e) {
+        e.preventDefault();
+        window.print();
+      };
+
+      // Get ancestor of an element based on matching attributes by traversing up the DOM
+      // > This is to make the print button visible when JavaScript is enabled
+      UK_Parliament.traverseUp(
+        printButtons[i],
+        {
+          'class': 'visually-hidden',
+          'aria-hidden': 'true'
+        },
+        function(parent) {
+          parent.classList.remove('visually-hidden');
+          parent.removeAttribute('aria-hidden');
+        }
+      );
+
+    }
+  }
+};
+
+UK_Parliament.printButton();

--- a/src/stylesheets/components/_hints.scss
+++ b/src/stylesheets/components/_hints.scss
@@ -17,6 +17,15 @@
   margin-right: $base-spacing-unit-tiny;
 }
 
+/*--- List ---*/
+
+[class*="list"] {
+  .hint,
+  .url {
+    margin-right: $base-spacing-unit;
+  }
+}
+
 /*--- URLs ---*/
 
 .hint,

--- a/src/stylesheets/components/_list-styles.scss
+++ b/src/stylesheets/components/_list-styles.scss
@@ -73,19 +73,12 @@ dl, dt, dd {
   }
   li {
     float: left;
+    margin-right: $base-spacing-unit-small;
   }
-  a, span {
-    display: block;
-    position: relative;
-    padding: ($base-spacing-unit-tiny / 2) $base-spacing-unit-tiny;
-  }
-}
-.list--inline {
-  @include list--inline;
 }
 
-article footer .list--inline {
-  margin-top: round($base-spacing-unit * 9);
+.list--inline {
+  @include list--inline;
 }
 
 @mixin list--details__inline {
@@ -197,25 +190,18 @@ article footer .list--inline {
   @include list--pipe;
 }
 
-article + aside .list--pipe li {
-  width: auto;
-  margin: 0 $base-spacing-unit-small;
-  &.active {
-    width: auto;
-    font-weight: 400;
-    background-color: $grey-3;
-    padding-right: $base-spacing-unit-small;
-    padding-left: $base-spacing-unit-small;
-    margin: -1px 0 0;
-  }
-}
-
 aside .list--pipe li {
+  margin: 0 $base-spacing-unit-small;
   &:first-child {
     border-top: 0;
   }
   &:last-child {
     border-bottom: 0;
+  }
+  &.active {
+    padding-right: $base-spacing-unit-small;
+    padding-left: $base-spacing-unit-small;
+    margin: -1px 0 0;
   }
 }
 
@@ -249,6 +235,11 @@ aside .list--pipe li {
   li.active {
     padding: ($base-spacing-unit + 2) 0;
     border-bottom: 4px solid $purple;
+  }
+  a, span {
+    display: block;
+    position: relative;
+    padding: ($base-spacing-unit-tiny / 2) $base-spacing-unit-tiny;
   }
   a {
     padding: ($base-spacing-unit + 2) 0;
@@ -365,6 +356,15 @@ article [role='main'] {
     ol > li {
       list-style-type: decimal;
     }
+  }
+}
+
+aside [class*="list"] li {
+  display: block;
+  width: auto;
+  &.active {
+    font-weight: 400;
+    background-color: $grey-3;
   }
 }
 

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -1,8 +1,21 @@
+/*--- Navigation Main, Letter & Number ---*/
+.navigation--main,
+.navigation--letter,
+.navigation--number {
+  @include list--inline;
+  li {
+    margin-right: 0;
+  }
+  a, span {
+    display: block;
+    position: relative;
+    padding: ($base-spacing-unit-tiny / 2) $base-spacing-unit-tiny;
+  }
+}
+
 /*--- Navigation Main ---*/
 
 .navigation--main {
-  @extend .list--inline;
-
   ol, ul {
     @include clearfix;
     list-style: none;
@@ -10,6 +23,23 @@
   }
   li {
     padding: 0 ($base-spacing-unit - 3);
+  }
+}
+
+/*--- Navigation Letter & Number ---*/
+
+.navigation--letter,
+.navigation--number {
+  ol, ul {
+    list-style: none;
+  }
+  li {
+    padding: 0;
+    text-align: center;
+    text-transform: capitalize;
+  }
+  span {
+    min-width: 24px;
   }
 }
 
@@ -40,25 +70,6 @@
     @include media($desktop) {
       padding: ($base-spacing-unit + 2px) 0;
     }
-  }
-}
-
-/*--- Navigation Letter & Number ---*/
-
-.navigation--letter,
-.navigation--number {
-  @extend .list--inline;
-
-  ol, ul {
-    list-style: none;
-  }
-  li {
-    padding: 0;
-    text-align: center;
-    text-transform: capitalize;
-  }
-  span {
-    min-width: 24px;
   }
 }
 

--- a/src/stylesheets/elements/_icons.scss
+++ b/src/stylesheets/elements/_icons.scss
@@ -120,3 +120,13 @@ svg [data-icon="file"] {
   height: 20px;
   margin-left: -4px;
 }
+
+/*--- List styles ---*/
+
+/* Adding space between the right of an SVG and the
+left of its sibling. SVG left spacing not required
+because our design pattern is to have SVGs on the
+left hand side. */
+[class*="list"] svg + * {
+  margin-left: $base-spacing-unit;
+}

--- a/src/templates/index.pug
+++ b/src/templates/index.pug
@@ -35,6 +35,7 @@ html(lang="en")
             li #[+link('/templates/prototypes/_buttons.html', 'Buttons')]
             li #[+link('/templates/prototypes/_forms.html', 'Form elements')]
             li #[+link('/templates/prototypes/_headings.html', 'Typography & Headings')]
+            li #[+link('/templates/prototypes/_icons.html', 'Icons')]
             li #[+link('/templates/prototypes/_lists.html', 'Lists')]
             li #[+link('/templates/prototypes/_navigations.html', 'Navigations')]
             li #[+link('/templates/prototypes/_tables.html', 'Tables')]

--- a/src/templates/prototypes/_icons.pug
+++ b/src/templates/prototypes/_icons.pug
@@ -1,0 +1,45 @@
+extends ../../layouts/layout.pug
+block content
+  -var thingPage = true
+
+  .section--primary(tabindex=0)#content
+    .container
+      h1 Icons
+
+  section
+    .container
+      h2 Small
+      table
+        tr
+          th Caution circle
+          th Close
+          th Download
+        tr
+          td
+            include ../../icons/caution-circle-white.svg
+          td
+            include ../../icons/close.svg
+          td
+            include ../../icons/download.svg
+        tr
+          th Print
+          th Search
+          th Share
+        tr
+          td
+            include ../../icons/print.svg
+          td
+            include ../../icons/search.svg
+          td
+            include ../../icons/share.svg
+
+      h2 Large
+      table
+        tr
+          th File
+          th UK Parliament
+        tr
+          td
+            include ../../icons/file.svg
+          td
+            include ../../icons/uk-parliament.svg

--- a/src/templates/prototypes/article.pug
+++ b/src/templates/prototypes/article.pug
@@ -47,6 +47,8 @@ block content
           h2 Up to:
           p #[+link('#', 'MPs Guide to Procedure')]
 
+          include ../../elements/_utilities.pug
+
       aside
         h2 Related Articles
         .block


### PR DESCRIPTION
## Main updates

- Included a list of icons page named *_icons.pug*, which is separated into two sections; small and large
- Updated the print and download SVGs
- Added a share icon SVG
- Updated any component with `@extend .list--inline` to use `@include list--inline` instead; this makes the use of `.list--inline` as an HTML class more flexible
- Moved styles for `.navigation--letter, .navigation--number` higher up in the file *_navigation.scss* to let their styles cascade correctly.
- Set a gap between links inside `.list--inline` inside article footers.
- Added default browser print functionality to print button.

## Extra updates

- Gave list items in sidebar `.list--pipe` CSS `display: block` to take full width of their container, which is a fix for tablet and mobile.
- Created a DOM parent traversal function that returns the ancestor of an element based on checking if it has matching HTML attributes specified by the user in as an argument