### PR TITLE
[bugfix] Article size at incorrect breakpoint

### DIFF
--- a/src/stylesheets/components/_article.scss
+++ b/src/stylesheets/components/_article.scss
@@ -1,7 +1,7 @@
 article {
   position: relative;
   margin: $base-spacing-unit-extra-large 0 $base-spacing-unit-small;
-  @include media($medium) {
+  @include media($large) {
     flex: 1;
     margin-top: ($base-spacing-unit-large * 2);
   }


### PR DESCRIPTION
- Article had an incorrect breakpoint, thereby causing article and aside to fail on Safari Ipad in portrait mode